### PR TITLE
ADD mrp_repair_layout

### DIFF
--- a/mrp_repair_layout/README.rst
+++ b/mrp_repair_layout/README.rst
@@ -1,0 +1,62 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+MRP repair layout
+=================
+
+With this module you can personalize the MRP repair order report with
+separators, page-breaks or subtotals.
+
+Configuration
+=============
+
+Under
+manufacturing -> configuration -> report layout categories
+configure your reports sections, setting their options (subtotal, separator,
+pagebreak and sequence)
+
+Usage
+=====
+
+In repair order lines, use the configured sections
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+manufacture/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+manufacture/issues/new?body=module:%20
+mrp_repair_layout%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/mrp_repair_layout/__init__.py
+++ b/mrp_repair_layout/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+#                                                                        #
+# Copyright 2015  Lorenzo Battistini - Agile Business Group              #
+# About license, see __openerp__.py                                      #
+#                                                                        #
+##########################################################################
+
+from . import models

--- a/mrp_repair_layout/__openerp__.py
+++ b/mrp_repair_layout/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+#                                                                        #
+# Copyright 2015  Lorenzo Battistini - Agile Business Group              #
+#                                                                        #
+# This program is free software: you can redistribute it and/or modify   #
+# it under the terms of the GNU Affero General Public License as         #
+# published by the Free Software Foundation, either version 3 of the     #
+# License, or (at your option) any later version.                        #
+#                                                                        #
+# This program is distributed in the hope that it will be useful,        #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of         #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          #
+# GNU Affero General Public License for more details.                    #
+#                                                                        #
+# You should have received a copy of the                                 #
+# GNU Affero General Public License                                      #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+##########################################################################
+
+
+{
+    'name': 'MRP Repair Layout',
+    'version': '8.0.1.0.0',
+    'category': 'Manufacturing',
+    'author': "Agile Business Group, Odoo Community Association (OCA)",
+    'website': 'http://www.agilebg.com',
+    'license': 'AGPL-3',
+    'depends': ['mrp_repair'],
+    'data': [
+        'views/layout_templates.xml',
+        'views/mrp_repair_layouted.xml',
+        'views/mrp_repair_layout_category_view.xml',
+        'views/mrp_repair_view.xml',
+        'security/ir.model.access.csv',
+        ],
+    'installable': True,
+}

--- a/mrp_repair_layout/models/__init__.py
+++ b/mrp_repair_layout/models/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+#                                                                        #
+# Copyright 2015  Lorenzo Battistini - Agile Business Group              #
+# About license, see __openerp__.py                                      #
+#                                                                        #
+##########################################################################
+
+from . import mrp_repair
+from . import mrp_repair_layout_category

--- a/mrp_repair_layout/models/mrp_repair.py
+++ b/mrp_repair_layout/models/mrp_repair.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+#                                                                        #
+# Copyright 2015  Lorenzo Battistini - Agile Business Group              #
+# About license, see __openerp__.py                                      #
+#                                                                        #
+##########################################################################
+
+from openerp import models, fields, api
+from itertools import groupby
+
+
+def sortkey(x):
+    return x.layout_cat_id if x.layout_cat_id else ''
+
+
+class MrpRepair(models.Model):
+    _inherit = 'mrp.repair'
+
+    @api.model
+    def grouplines(self, ordered_lines, sortkey):
+        grouped_lines = []
+        for key, valuesiter in groupby(ordered_lines, sortkey):
+            group = {}
+            group['category'] = key
+            group['lines'] = list(v for v in valuesiter)
+
+            if 'subtotal' in key and key.subtotal is True:
+                group['subtotal'] = sum(
+                    line.price_subtotal for line in group['lines'])
+            grouped_lines.append(group)
+
+        return grouped_lines
+
+    @api.model
+    def repair_layout_operation_lines(self, order):
+        ordered_lines = order.operations
+        lines_to_print = [l for l in ordered_lines if l.to_invoice]
+        return self.grouplines(lines_to_print, sortkey)
+
+    @api.model
+    def repair_layout_fee_lines(self, order):
+        ordered_lines = order.fees_lines
+        lines_to_print = [l for l in ordered_lines if l.to_invoice]
+        return self.grouplines(lines_to_print, sortkey)
+
+
+class MrpRepairLine(models.Model):
+    _inherit = 'mrp.repair.line'
+    _order = 'repair_id, categ_sequence, layout_cat_id, id'
+    layout_cat_id = fields.Many2one(
+        'mrp_repair.layout.category', 'Section')
+    categ_sequence = fields.Integer(
+        related='layout_cat_id.sequence', string='Layout sequence',
+        store=True, default=0)
+
+
+class MrpRepairFee(models.Model):
+    _inherit = 'mrp.repair.fee'
+    _order = 'repair_id, categ_sequence, layout_cat_id, id'
+    layout_cat_id = fields.Many2one(
+        'mrp_repair.layout.category', 'Section')
+    categ_sequence = fields.Integer(
+        related='layout_cat_id.sequence', string='Layout sequence',
+        store=True, default=0)

--- a/mrp_repair_layout/models/mrp_repair.py
+++ b/mrp_repair_layout/models/mrp_repair.py
@@ -47,19 +47,21 @@ class MrpRepair(models.Model):
 
 class MrpRepairLine(models.Model):
     _inherit = 'mrp.repair.line'
-    _order = 'repair_id, categ_sequence, layout_cat_id, id'
+    _order = 'repair_id, categ_sequence, layout_cat_id, sequence, id'
     layout_cat_id = fields.Many2one(
         'mrp_repair.layout.category', 'Section')
     categ_sequence = fields.Integer(
         related='layout_cat_id.sequence', string='Layout sequence',
         store=True, default=0)
+    sequence = fields.Integer('Sequence')
 
 
 class MrpRepairFee(models.Model):
     _inherit = 'mrp.repair.fee'
-    _order = 'repair_id, categ_sequence, layout_cat_id, id'
+    _order = 'repair_id, categ_sequence, layout_cat_id, sequence, id'
     layout_cat_id = fields.Many2one(
         'mrp_repair.layout.category', 'Section')
     categ_sequence = fields.Integer(
         related='layout_cat_id.sequence', string='Layout sequence',
         store=True, default=0)
+    sequence = fields.Integer('Sequence')

--- a/mrp_repair_layout/models/mrp_repair_layout_category.py
+++ b/mrp_repair_layout/models/mrp_repair_layout_category.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+#                                                                        #
+# Copyright 2015  Lorenzo Battistini - Agile Business Group              #
+# About license, see __openerp__.py                                      #
+#                                                                        #
+##########################################################################
+
+from openerp import models, fields
+
+
+class MrpRepairLayoutCategory(models.Model):
+    _name = 'mrp_repair.layout.category'
+    name = fields.Char('Name', required=True)
+    sequence = fields.Integer('Sequence', required=True, default=10)
+    subtotal = fields.Boolean('Add subtotal', default=True)
+    separator = fields.Boolean('Add separator', default=True)
+    pagebreak = fields.Boolean('Add pagebreak')

--- a/mrp_repair_layout/security/ir.model.access.csv
+++ b/mrp_repair_layout/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+report_layout_category,report_layout_category,model_mrp_repair_layout_category,mrp.group_mrp_manager,1,1,1,1
+report_layout_category_user,report_layout_category_user,model_mrp_repair_layout_category,mrp.group_mrp_user,1,0,0,0

--- a/mrp_repair_layout/views/layout_templates.xml
+++ b/mrp_repair_layout/views/layout_templates.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+<template id="category_template">
+    <!-- Category name -->
+    <t t-if="p['category']">
+        <tr>
+            <td colspan="100" class="active" style="border-bottom: 1px solid black; padding-left:15px">&amp;bull; 
+                <t t-if="p['category'].name">
+                    <t t-esc="p['category'].name"></t>
+                </t>
+                <t t-if="not p['category'].name">
+                    Uncategorized
+                </t>
+            </td>
+        </tr>
+    </t>
+</template>
+
+<template id="subtotal_template">
+    <!-- Subtotal -->
+    <t t-if="'subtotal' in p['category'] and p['category'].subtotal is True">
+        <tr class="text-right">
+            <td colspan="100">
+                <strong>Subtotal: </strong>
+                <span t-esc="p['subtotal']" t-esc-options='{"widget": "monetary", "display_currency": "o.pricelist_id.currency_id"}'/>
+            </td>
+        </tr>
+    </t>
+</template>
+
+<template id="separator_template">
+    <!-- Separator -->
+    <t t-if="'separator' in p['category'] and p['category'].separator is True">
+        <tr class="text-center">
+            <td colspan="100">
+                ***
+            </td>
+        </tr>
+    </t>
+</template>
+</data>
+</openerp>

--- a/mrp_repair_layout/views/mrp_repair_layout_category_view.xml
+++ b/mrp_repair_layout/views/mrp_repair_layout_category_view.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="mrp_repair_layout_category_form_view" model="ir.ui.view">
+            <field name="name">mrp_repair.layout.category.form.view</field>
+            <field name="model">mrp_repair.layout.category</field>
+            <field name="arch" type="xml">
+                <form string="Report Configuration">
+                    <group>
+                        <field name="name"/>
+                        <field name="subtotal" widget="checkbox"/>
+                        <field name="separator" widget="checkbox"/>
+                        <field name="pagebreak" widget="checkbox"/>
+                        <field name="sequence"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="mrp_repair_layout_category_tree_view" model="ir.ui.view">
+            <field name="name">mrp_repair.layout.category.tree.view</field>
+            <field name="model">mrp_repair.layout.category</field>
+            <field name="arch" type="xml">
+                <tree string="Report Configuration">
+                        <field name="name"/>
+                        <field name="subtotal" widget="checkbox"/>
+                        <field name="separator" widget="checkbox"/>
+                        <field name="pagebreak" widget="checkbox"/>
+                        <field name="sequence"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="mrp_repair_layout_category_search_view" model="ir.ui.view" >
+	        <field name="name">mrp_repair.layout.category.search.view</field>
+	        <field name="model">mrp_repair.layout.category</field>
+	        <field name="arch" type="xml">
+                <search string="Search Name">
+                    <filter string="Total" domain="[('subtotal','=','True')]"/>
+                    <filter string="Separator" domain="[('separator','=','True')]"/>
+                    <filter string="Break" domain="[('pagebreak','=','True')]"/>
+                    <group string="Group By Name">
+                        <filter string="Name"  context="{'group_by' : 'name'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id='report_configuration_action' model='ir.actions.act_window'>
+            <field name="name">Report Configuration</field>
+            <field name="res_model">mrp_repair.layout.category</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <menuitem 
+            action="report_configuration_action" 
+            id="Report_configuration" 
+            parent="mrp.menu_mrp_configuration"
+            name="Report Layout Categories"
+        />
+    </data>
+</openerp>

--- a/mrp_repair_layout/views/mrp_repair_layouted.xml
+++ b/mrp_repair_layout/views/mrp_repair_layouted.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="report_mrp_repair_layouted" inherit_id="mrp_repair.report_mrprepairorder">
+            <xpath expr="//tr[@t-foreach='o.operations']" position="replace">
+                <t t-foreach="o.repair_layout_operation_lines(o)" t-as="p">
+                    <t t-call="mrp_repair_layout.category_template" />
+                    <t t-foreach="p['lines']" t-as="line">
+                        <tr>
+                            <td style="padding-left:20px">
+                                <p t-if="line.type == 'add'"><i>(Add)</i> <span t-field="line.name" /></p>
+                                <p t-if="line.type == 'remove'"><i>(Remove)</i> <span t-field="line.name"/></p>
+                            </td>
+                            <td class="text-center">
+                                <span t-esc="','.join(map( lambda x: x.name, line.tax_id))"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="line.product_uom_qty"/>
+                                <span groups="product.group_uom" t-field="line.product_uom.name"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="line.price_unit"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="line.price_subtotal" 
+                                    t-field-options='{"widget": "monetary", "display_currency": "o.pricelist_id.currency_id"}'/>
+                           </td>
+                        </tr>
+                    </t>
+                    <!-- Subtotal -->
+                    <t t-call="mrp_repair_layout.subtotal_template" />
+
+                    <!-- Separator -->
+                    <t t-call="mrp_repair_layout.separator_template" />
+                    
+                    <!-- Pagebreak -->
+                    <t t-if="'pagebreak' in p['category'] and p['category'].pagebreak is True">
+                        <t t-if="p_index &lt; p_size - 1">
+                            <![CDATA[
+                                </tbody>
+                            </table>
+                            <p style="page-break-before:always;"> </p>
+                            <table class="table table-condensed">
+                            ]]>
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th class="text-center">Tax</th>
+                                    <th class="text-right">Quantity</th>
+                                    <th class="text-right">Unit Price</th>
+                                    <th class="text-right">Price</th>
+                                </tr>
+                            </thead>
+                            <![CDATA[
+                                <tbody>
+                            ]]>
+                        </t>
+                    </t>
+                </t>
+            </xpath>
+
+            <xpath expr="//tr[@t-foreach='o.fees_lines']" position="replace">
+                <t t-foreach="o.repair_layout_fee_lines(o)" t-as="p">
+                    <t t-call="mrp_repair_layout.category_template" />
+                    <t t-foreach="p['lines']" t-as="fees">
+                        <tr>
+                            <td style="padding-left:20px">
+                                <span t-field="fees.name"/>
+                            </td>
+                            <td class="text-center">
+                                <span t-esc="','.join(map( lambda x: x.name, fees.tax_id))"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="fees.product_uom_qty"/>
+                                <span groups="product.group_uom" t-field="fees.product_uom.name"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="fees.price_unit"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="fees.price_subtotal"
+                                    t-field-options='{"widget": "monetary", "display_currency": "o.pricelist_id.currency_id"}'/>
+                           </td>
+                        </tr>
+                    </t>
+                    <!-- Subtotal -->
+                    <t t-call="mrp_repair_layout.subtotal_template" />
+
+                    <!-- Separator -->
+                    <t t-call="mrp_repair_layout.separator_template" />
+                    
+                    <!-- Pagebreak -->
+                    <t t-if="'pagebreak' in p['category'] and p['category'].pagebreak is True">
+                        <t t-if="p_index &lt; p_size - 1">
+                            <![CDATA[
+                                </tbody>
+                            </table>
+                            <p style="page-break-before:always;"> </p>
+                            <table class="table table-condensed">
+                            ]]>
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th class="text-center">Tax</th>
+                                    <th class="text-right">Quantity</th>
+                                    <th class="text-right">Unit Price</th>
+                                    <th class="text-right">Price</th>
+                                </tr>
+                            </thead>
+                            <![CDATA[
+                                <tbody>
+                            ]]>
+                        </t>
+                    </t>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</openerp>

--- a/mrp_repair_layout/views/mrp_repair_view.xml
+++ b/mrp_repair_layout/views/mrp_repair_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_repair_order_form_layout" model="ir.ui.view">
+            <field name="name">mrp.repair.form.layout</field>
+            <field name="model">mrp.repair</field>
+            <field name="inherit_id" ref="mrp_repair.view_repair_order_form"></field>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Repair Line']/group/field[@name='product_id']" position="after">
+                    <field name="layout_cat_id"/>
+                </xpath>
+                <xpath expr="//tree[@string='Operations']/field[@name='product_id']" position="after">
+                    <field name="layout_cat_id"/>
+                </xpath>
+                <xpath expr="//group[@string='Product Information']/group[1]/field[@name='product_id']" position="after">
+                    <field name="layout_cat_id"/>
+                </xpath>
+                <xpath expr="//tree[@string='Fees']/field[@name='product_id']" position="after">
+                    <field name="layout_cat_id"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/mrp_repair_layout/views/mrp_repair_view.xml
+++ b/mrp_repair_layout/views/mrp_repair_view.xml
@@ -12,11 +12,17 @@
                 <xpath expr="//tree[@string='Operations']/field[@name='product_id']" position="after">
                     <field name="layout_cat_id"/>
                 </xpath>
+                <xpath expr="//tree[@string='Operations']/field[@name='type']" position="before">
+                    <field name="sequence" widget="handle"/>
+                </xpath>
                 <xpath expr="//group[@string='Product Information']/group[1]/field[@name='product_id']" position="after">
                     <field name="layout_cat_id"/>
                 </xpath>
                 <xpath expr="//tree[@string='Fees']/field[@name='product_id']" position="after">
                     <field name="layout_cat_id"/>
+                </xpath>
+                <xpath expr="//tree[@string='Fees']/field[@name='product_id']" position="before">
+                    <field name="sequence" widget="handle"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
# 
# MRP repair layout

With this module you can personalize the MRP repair order report with
separators, page-breaks or subtotals.
# Configuration

Under
manufacturing -> configuration -> report layout categories
configure your reports sections, setting their options (subtotal, separator,
pagebreak and sequence)
# Usage

In repair order lines, use the configured sections
