### PR TITLE
[8.0][mrp_bom_structure_xls] Allow more than 6 levels of indentation

### DIFF
--- a/mrp_bom_structure_xls/README.rst
+++ b/mrp_bom_structure_xls/README.rst
@@ -26,7 +26,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/manufacture-reporting/issues>`_. In case of trouble,
 please check there if your issue has already been reported. If you spotted it
- first, help us smash it by providing detailed and welcomed feedback.
+first, help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/mrp_bom_structure_xls/report/bom_structure_xls.py
+++ b/mrp_bom_structure_xls/report/bom_structure_xls.py
@@ -37,7 +37,7 @@ class BomStructureInh(bom_structure):
                         level -= 1
             return result
 
-        children = _get_rec(object,level)
+        children = _get_rec(object, level)
 
         return children
 

--- a/mrp_bom_structure_xls/report/bom_structure_xls.py
+++ b/mrp_bom_structure_xls/report/bom_structure_xls.py
@@ -10,7 +10,7 @@ from openerp.addons.mrp.report.bom_structure \
 from openerp.tools.translate import _
 
 
-class bom_structure_inh(bom_structure):
+class BomStructureInh(bom_structure):
     def __init__(self, cr, uid, name, context):
         super(bom_structure, self).__init__(cr, uid, name, context=context)
         self.localcontext.update({
@@ -154,4 +154,4 @@ class BomStructureXls(report_xls):
                                                   _p, data)
 
 
-BomStructureXls('report.bom.structure.xls', 'mrp.bom', parser=bom_structure_inh)
+BomStructureXls('report.bom.structure.xls', 'mrp.bom', parser=BomStructureInh)

--- a/mrp_bom_structure_xls/report/bom_structure_xls.py
+++ b/mrp_bom_structure_xls/report/bom_structure_xls.py
@@ -10,6 +10,38 @@ from openerp.addons.mrp.report.bom_structure \
 from openerp.tools.translate import _
 
 
+class bom_structure_inh(bom_structure):
+    def __init__(self, cr, uid, name, context):
+        super(bom_structure, self).__init__(cr, uid, name, context=context)
+        self.localcontext.update({
+            'get_children': self.get_children,
+        })
+
+    def get_children(self, object, level=0):
+        result = []
+
+        def _get_rec(object, level):
+            for l in object:
+                res = {}
+                res['pname'] = l.product_id.name
+                res['pcode'] = l.product_id.default_code
+                res['pqty'] = l.product_qty
+                res['uname'] = l.product_uom.name
+                res['level'] = level
+                res['code'] = l.bom_id.code
+                result.append(res)
+                if l.child_line_ids:
+                    level += 1
+                    _get_rec(l.child_line_ids, level)
+                    if level > 0:
+                        level -= 1
+            return result
+
+        children = _get_rec(object,level)
+
+        return children
+
+
 class BomStructureXls(report_xls):
     column_sizes = [40, 20, 20, 40, 20, 20, 20]
 
@@ -122,4 +154,4 @@ class BomStructureXls(report_xls):
                                                   _p, data)
 
 
-BomStructureXls('report.bom.structure.xls', 'mrp.bom', parser=bom_structure)
+BomStructureXls('report.bom.structure.xls', 'mrp.bom', parser=bom_structure_inh)


### PR DESCRIPTION
The column 'level' was showing only 6 levels of indentations. This PR allows to compose any number of levels of indentation.