### PR TITLE
[13.0][FIX] Missing description across manufacture-reporting modules

### DIFF
--- a/mrp_bom_structure_xlsx/report/bom_structure_xlsx.py
+++ b/mrp_bom_structure_xlsx/report/bom_structure_xlsx.py
@@ -11,6 +11,7 @@ _logger = logging.getLogger(__name__)
 
 class BomStructureXlsx(models.AbstractModel):
     _name = "report.mrp_bom_structure_xlsx.bom_structure_xlsx"
+    _description = "BOM Structure XLSX Report"
     _inherit = "report.report_xlsx.abstract"
 
     def print_bom_children(self, ch, sheet, row, level):

--- a/mrp_bom_structure_xlsx_level_1/report/bom_structure_xlsx.py
+++ b/mrp_bom_structure_xlsx_level_1/report/bom_structure_xlsx.py
@@ -10,6 +10,7 @@ _logger = logging.getLogger(__name__)
 
 class BomStructureXlsxL1(models.AbstractModel):
     _name = "report.mrp_bom_structure_xlsx_l1.bom_structure_xlsx_l1"
+    _description = "BOM Structure XLSX Level 1 Report"
     _inherit = "report.mrp_bom_structure_xlsx.bom_structure_xlsx"
 
     def print_bom_children(self, ch, sheet, row, level):


### PR DESCRIPTION
Avoid:
```
2020-02-26 10:47:08,684 52 WARNING database odoo.models: The model report.mrp_bom_structure_xlsx.bom_structure_xlsx has no _description 
2020-02-26 10:47:09,465 52 WARNING database odoo.models: The model report.mrp_bom_structure_xlsx_l1.bom_structure_xlsx_l1 has no _description
```

CC @ForgeFlow 