### PR TITLE
[12.0][IMP] mrb_bom_current_stock

### DIFF
--- a/mrp_bom_current_stock/i18n/de.po
+++ b/mrp_bom_current_stock/i18n/de.po
@@ -1,0 +1,321 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* mrp_bom_current_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-08 10:57+0000\n"
+"PO-Revision-Date: 2020-06-08 13:01+0200\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: de\n"
+"X-Generator: Poedit 2.3.1\n"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:35
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+#, python-format
+msgid "BOM Current Stock Report"
+msgstr "BOM Bericht zum aktuellen Lagerbestand"
+
+#. module: mrp_bom_current_stock
+#: model:ir.actions.act_window,name:mrp_bom_current_stock.mrp_bom_current_stock_action
+#: model:ir.ui.menu,name:mrp_bom_current_stock.mrp_bom_current_stock_menu
+msgid "BoM Current Stock Explosion"
+msgstr "BoM Aktuelle Lagerbestands-Explosion"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__bom_level
+msgid "BoM Level"
+msgstr "BoM-Ebene"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:53
+#, python-format
+msgid "BoM Reference"
+msgstr "BoM-Referenz"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__bom_line
+msgid "BoM line"
+msgstr "BoM-Linie"
+
+#. module: mrp_bom_current_stock
+#: model:ir.actions.report,name:mrp_bom_current_stock.action_report_bom_current_stock_pdf
+msgid "BoM: Current Stock Report PDF"
+msgstr "BoM: Aktueller Aktienbericht PDF"
+
+#. module: mrp_bom_current_stock
+#: model:ir.actions.report,name:mrp_bom_current_stock.action_report_bom_current_stock_xlsx
+msgid "BoM: Current Stock Report XLSX"
+msgstr "BoM: Aktueller Aktienbericht XLSX"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "Close"
+msgstr "Schließen"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__create_uid
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__create_uid
+msgid "Created by"
+msgstr "Erstellt von"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__create_date
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__create_date
+msgid "Created on"
+msgstr "Erstellt am"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__display_name
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__display_name
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_report_mrp_bom_current_stock_report_mrpbom_current_stock_xlsx__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form
+msgid "Explode"
+msgstr "Explodieren"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__explosion_id
+msgid "Explosion"
+msgstr "Explosion"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "Explosion result"
+msgstr "Ergebnis der Explosion"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "Export XLSX"
+msgstr "XLSX exportieren"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__id
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__id
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_report_mrp_bom_current_stock_report_mrpbom_current_stock_xlsx__id
+msgid "ID"
+msgstr ""
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock____last_update
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line____last_update
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_report_mrp_bom_current_stock_report_mrpbom_current_stock_xlsx____last_update
+msgid "Last Modified on"
+msgstr "Zuletzt geändert am"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__write_uid
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__write_uid
+msgid "Last Updated by"
+msgstr "Zuletzt aktualisiert durch"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__write_date
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__write_date
+msgid "Last Updated on"
+msgstr "Zuletzt aktualisiert am"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:52
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+#, python-format
+msgid "Level"
+msgstr "Ebene"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__line_ids
+msgid "Line"
+msgstr "Zeile"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:58
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+#, python-format
+msgid "Location"
+msgstr "Lagerort"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+msgid "Location:"
+msgstr "Location:"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model,name:mrp_bom_current_stock.model_mrp_bom_current_stock
+msgid "MRP Bom Route Current Stock"
+msgstr "MRP Bom Route Aktueller Bestand"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model,name:mrp_bom_current_stock.model_mrp_bom_current_stock_line
+msgid "MRP Bom Route Current Stock Line"
+msgstr "MRP Bom Route Aktuelle Lagerlinie"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__bom_id
+msgid "Parent BoM"
+msgstr "Mutterstückliste"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:59
+#, python-format
+msgid "Parent BoM Ref"
+msgstr "Ref. Elternteil BoM"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:60
+#, python-format
+msgid "Parent Product Ref"
+msgstr "Übergeordnetes Produkt Ref"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "Print PDF"
+msgstr "PDF drucken"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+msgid "Product"
+msgstr "Produkt"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__product_qty
+msgid "Product Quantity"
+msgstr "Produktmenge"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:54
+#, python-format
+msgid "Product Reference"
+msgstr "Produkt-Referenz"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__product_tmpl_id
+msgid "Product Template"
+msgstr "Produktvorlage"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__product_uom_id
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__product_uom_id
+msgid "Product Unit of Measure"
+msgstr "Produkteinheit"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__product_id
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__product_id
+msgid "Product Variant"
+msgstr "Produktvarianten"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:56
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+#, python-format
+msgid "Qty Available (Location)"
+msgstr "Verfügbare Menge (Standort)"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__qty_available_in_source_loc
+msgid "Qty Available in Source"
+msgstr "Verfügbare Menge in Quelle"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:55
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__product_qty
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+#, python-format
+msgid "Quantity"
+msgstr "Menge"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:61
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__qty_able_to_produce
+#, python-format
+msgid "Quantity Able to Produce Immediately"
+msgstr "Sofort produzierbare Menge"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+msgid "Quantity Able to Produce Immediately:"
+msgstr "Sofort produzierbare Menge:"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form
+msgid "Select product and location to explode"
+msgstr "Wählen Sie das zu explodierende Produkt und den Standort"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "Set the source location for every component."
+msgstr "Legen Sie den Quellort für jede Komponente fest."
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock_line__location_id
+msgid "Source location"
+msgstr "Ort der Quelle"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__bom_id
+msgid "Starting Bill of Materials"
+msgstr "Ausgangsstückliste"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__location_id
+msgid "Starting location"
+msgstr "Ausgangsort"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,help:mrp_bom_current_stock.field_mrp_bom_current_stock__qty_able_to_produce
+msgid "This is the quantity of top level product that can be manufactured directly with only one production order without the need of any extra operation, i.e., taking into account onlylevel 1."
+msgstr "Dies ist die Menge des Spitzenprodukts, die direkt mit nur einem Fertigungsauftrag ohne zusätzlichen Vorgang, d.h. unter Berücksichtigung von nur Stufe 1, hergestellt werden kann."
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,help:mrp_bom_current_stock.field_mrp_bom_current_stock__total_qty_able_to_produce
+msgid "This is the quantity of top level product that can be manufactured with what is currently on stock taking into accountall components in the BoM."
+msgstr "Dies ist die Menge des Spitzenprodukts, die mit dem, was derzeit auf Lager ist, unter Berücksichtigung aller Komponenten im BoM hergestellt werden kann."
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:62
+#: model:ir.model.fields,field_description:mrp_bom_current_stock.field_mrp_bom_current_stock__total_qty_able_to_produce
+#, python-format
+msgid "Total Quantity Able to Produce"
+msgstr "Produzierbare Gesamtmenge"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.report_mrpbom_current_stock_pdf
+msgid "Total Quantity Able to Produce:"
+msgstr "Produzierbare Gesamtmenge:"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model.fields,help:mrp_bom_current_stock.field_mrp_bom_current_stock__product_uom_id
+msgid "Unit of Measure (Unit of Measure) is the unit of measurement for the inventory control"
+msgstr "Mengeneinheit (ME) ist die Einheit, in der der Lagerbestand geführt wird"
+
+#. module: mrp_bom_current_stock
+#: code:addons/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py:57
+#, python-format
+msgid "UoM"
+msgstr "ME"
+
+#. module: mrp_bom_current_stock
+#: model_terms:ir.ui.view,arch_db:mrp_bom_current_stock.mrp_bom_current_stock_view_form2
+msgid "or"
+msgstr "oder"
+
+#. module: mrp_bom_current_stock
+#: model:ir.model,name:mrp_bom_current_stock.model_report_mrp_bom_current_stock_report_mrpbom_current_stock_xlsx
+msgid "report.mrp_bom_current_stock.report_mrpbom_current_stock_xlsx"
+msgstr ""

--- a/mrp_bom_current_stock/reports/report_mrpcurrentstock.xml
+++ b/mrp_bom_current_stock/reports/report_mrpcurrentstock.xml
@@ -8,6 +8,20 @@
                     <h2>BOM Current Stock Report</h2>
                      <t t-foreach="docs" t-as="o">
                          <table class="table table-condensed">
+                             <tr>
+                                <th>Quantity Able to Produce Immediately:</th>
+                                <td>
+                                    <span t-field="o.qty_able_to_produce"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Total Quantity Able to Produce:</th>
+                                <td>
+                                    <span t-field="o.total_qty_able_to_produce"/>
+                                </td>
+                            </tr>
+                         </table>
+                         <table class="table table-condensed">
                             <thead>
                                 <tr>
                                     <th>Location:</th>

--- a/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py
+++ b/mrp_bom_current_stock/reports/report_mrpcurrentstock_xlsx.py
@@ -43,6 +43,8 @@ class ReportMrpBomCurrentStockXlsx(models.AbstractModel):
         sheet.set_column(5, 5, 7)
         sheet.set_column(6, 6, 20)
         sheet.set_column(7, 8, 40)
+        sheet.set_column(9, 9, 40)
+        sheet.set_column(10, 10, 40)
 
         title_style = workbook.add_format({'bold': True,
                                            'bg_color': '#FFFFCC',
@@ -56,6 +58,8 @@ class ReportMrpBomCurrentStockXlsx(models.AbstractModel):
                        _('Location'),
                        _('Parent BoM Ref'),
                        _('Parent Product Ref'),
+                       _('Quantity Able to Produce Immediately'),
+                       _('Total Quantity Able to Produce'),
                        ]
         sheet.set_row(0, None, None, {'collapsed': 1})
         sheet.write_row(1, 0, sheet_title, title_style)
@@ -71,6 +75,9 @@ class ReportMrpBomCurrentStockXlsx(models.AbstractModel):
             sheet.write(i, 3, o.product_qty or '', bold)
             sheet.write(i, 5, o.product_uom_id.name or '', bold)
             sheet.write(i, 6, o.location_id.name or '', bold)
+
+            sheet.write(i, 9, o.qty_able_to_produce or '', bold)
+            sheet.write(i, 10, o.total_qty_able_to_produce or '', bold)
             i += 1
             for ch in o.line_ids:
                 i = self._print_bom_children(ch, sheet, i)

--- a/mrp_bom_current_stock/wizard/bom_route_current_stock_view.xml
+++ b/mrp_bom_current_stock/wizard/bom_route_current_stock_view.xml
@@ -37,9 +37,14 @@
         <field name="arch" type="xml">
             <form>
                 <group name="step_2" string="Explosion result">
-                    <p>Set the source location for every component.</p><br></br>
+                    <br/>
                     <field name="product_id" readonly="1"/>
                     <field name="bom_id" readonly="1"/>
+                    <br/>
+                    <field name="qty_able_to_produce" readonly="1"/>
+                    <field name="total_qty_able_to_produce" readonly="1"/>
+                    <br/><br/>
+                    <p>Set the source location for every component.</p>
                     <field name="line_ids" nolabel="1" colspan="2">
                         <tree create="0" delete="0" editable="1">
                             <field name="bom_level" readonly="1"/>


### PR DESCRIPTION
 This improvement adds top product availability to produce with current stock.

Two fields are added:

- Immediate availability: This is the addition of the current stock quantity for that product plus the amount of product that you could directly build with the components in the level one of the BoM without the need of extra Manufacturing Orders
- Total availability:  This is the addition of the current stock quantity for that product plus the maximum amount of product that can be build with the components' current stock taking into account all component even if that meant that extra Manufacturing Orders for low level components would be required.

cc ~ @ForgeFlow, @LoisRForgeFlow 