### PR TITLE
[12.0][FIX] mrp_bom_current_stock: Improve filter wizard to not filtered lines without location when not defined location in wizard

### DIFF
--- a/mrp_bom_current_stock/wizard/bom_route_current_stock.py
+++ b/mrp_bom_current_stock/wizard/bom_route_current_stock.py
@@ -81,7 +81,7 @@ class BomRouteCurrentStock(models.TransientModel):
                 line_boms = line.product_id.bom_ids
                 boms = line_boms.filtered(
                     lambda bom: bom.location_id == location
-                ) or line_boms.filtered(lambda b: not b.location_id)
+                ) or line_boms
                 if boms:
                     line_qty = line.product_uom_id._compute_quantity(
                         line.product_qty,


### PR DESCRIPTION
Improve filter wizard to not filtered lines without location when not defined location in wizard.

IMO it's important to change it because is possible to happen something like this:

- Create BOM A: Component A + Component B
- Create BOM B: BOM A + Component C
- Set any location to BOM A
- Use "_BoM Current Stock Explosion_" to report info about BOM B without location define.

**Now**: Not appear info related to BOM A + lines
**Expected**: Appear all info related to BOM B  + lines (include BOM A + lines).

What do you think about it @HviorForgeFlow @JordiBForgeFlow ?

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT28814