### PR TITLE
[13.0][FIX] mrp_bom_current_stock: Improve filter wizard to not filtered lines without location when not defined location in wizard

### DIFF
--- a/mrp_bom_current_stock/wizard/bom_route_current_stock.py
+++ b/mrp_bom_current_stock/wizard/bom_route_current_stock.py
@@ -71,9 +71,10 @@ class BomRouteCurrentStock(models.TransientModel):
                 line_obj.create(vals)
                 location = line.location_id
                 line_boms = line.product_id.bom_ids
-                boms = line_boms.filtered(
-                    lambda bom: bom.location_id == location
-                ) or line_boms.filtered(lambda b: not b.location_id)
+                boms = (
+                    line_boms.filtered(lambda bom: bom.location_id == location)
+                    or line_boms
+                )
                 if boms:
                     line_qty = line.product_uom_id._compute_quantity(
                         line.product_qty, boms[0].product_uom_id


### PR DESCRIPTION
It's FWP from 12.0: https://github.com/OCA/manufacture-reporting/pull/83

Improve filter wizard to not filtered lines without location when not defined location in wizard.

IMO it's important to change it because is possible to happen something like this:

- Create BOM A: Component A + Component B
- Create BOM B: BOM A + Component C
- Set any location to BOM A
- Use "_BoM Current Stock Explosion_" to report info about BOM B without location define.

**Now**: Not appear info related to BOM A + lines
**Expected**: Appear all info related to BOM B  + lines (include BOM A + lines).

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT28814