### PR TITLE
fixed wrong BOM selection in recursion by filtering BOMs of product variant

### DIFF
--- a/mrp_bom_current_stock/wizard/bom_route_current_stock.py
+++ b/mrp_bom_current_stock/wizard/bom_route_current_stock.py
@@ -70,7 +70,7 @@ class BomRouteCurrentStock(models.TransientModel):
                 vals = self._prepare_line(line, level, factor)
                 line_obj.create(vals)
                 location = line.location_id
-                line_boms = line.product_id.bom_ids
+                line_boms = line.product_id.bom_ids.filtered(lambda bom: bom.product_id == line.product_id)
                 boms = (
                     line_boms.filtered(lambda bom: bom.location_id == location)
                     or line_boms

--- a/mrp_bom_current_stock/wizard/bom_route_current_stock.py
+++ b/mrp_bom_current_stock/wizard/bom_route_current_stock.py
@@ -70,7 +70,9 @@ class BomRouteCurrentStock(models.TransientModel):
                 vals = self._prepare_line(line, level, factor)
                 line_obj.create(vals)
                 location = line.location_id
-                line_boms = line.product_id.bom_ids.filtered(lambda bom: bom.product_id == line.product_id)
+                line_boms = line.product_id.bom_ids.filtered(
+                    lambda bom: bom.product_id == line.product_id
+                )
                 boms = (
                     line_boms.filtered(lambda bom: bom.location_id == location)
                     or line_boms


### PR DESCRIPTION
without this, the first BOM of the product template is selected, irregardless of which product variant is in the BOM line